### PR TITLE
dagger: mark it source provenance as binary

### DIFF
--- a/pkgs/dagger/default.nix
+++ b/pkgs/dagger/default.nix
@@ -52,6 +52,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://dagger.io";
     license = lib.licenses.asl20;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
It is useful to provide this metadata for users consuming this NUR and having policy checks based on the source provenance.

See the manual on meta and stdenv in nixpkgs to understand what are the options.

> Adding this information helps users who have needs related to build transparency and supply-chain security to gain some visibility into their installed software or set policy to allow or disallow installation based on source provenance.