### PR TITLE
corrected usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
   outputs = { self, nixpkgs, flake-utils, dagger, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {inherit system};
       in {
-        devShell = pkgs.mkShell {
-          buildInputs = [ dagger.packages.dagger ];
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ dagger.packages.${system}.dagger ];
         };
       });
 }


### PR DESCRIPTION
the usage example wasn't working and nix was complaining about deprecated `devShell` target.