### PR TITLE
Remove 23.05 channel & add 24.05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
         nixPath:
           - nixpkgs=channel:nixos-unstable
           - nixpkgs=channel:nixpkgs-unstable
-          - nixpkgs=channel:nixos-23.05
           - nixpkgs=channel:nixos-23.11
+          - nixpkgs=channel:nixos-24.05
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
I was in two minds whether to keep the 23.11 channel. Seeing it as deprecated on https://search.nixos.org/packages made me keep it. WDYT @sagikazarmark?