### PR TITLE
install shell completions

### DIFF
--- a/pkgs/dagger/default.nix
+++ b/pkgs/dagger/default.nix
@@ -37,8 +37,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./dagger $out/bin/dagger
+    runHook postInstall
   '';
   postInstall = ''
     installShellCompletion --cmd dagger \


### PR DESCRIPTION
# This PR for installing shell completions using nix

## Summary
Shell completions are not installed when installing when following the [flake usage guide](https://github.com/dagger/nix#as-flake).

## Steps to reproduce
1. Create a tmp directory
```
mkdir ~/tmp-no_shell_completions
```
2. Copy the [flake usage guide](https://github.com/dagger/nix#as-flake) to `~/tmp-no_shell_completions/flake.nix`
3. Change directory
```
cd ~/tmp-no_shell_completions
```
4. Install dagger in the nix shell
```
nix develop
```
5. Find where dagger has been installed in the nix store
```
which dagger
/nix/store/5hgmqlys9vnrpwhrlwyccai5g2fk1686-dagger-0.13.5/bin/dagger
```
6. Note that `no` shell completion have been installed
```
tree /nix/store/5hgmqlys9vnrpwhrlwyccai5g2fk1686-dagger-0.13.5
/nix/store/5hgmqlys9vnrpwhrlwyccai5g2fk1686-dagger-0.13.5
└── bin
    └── dagger
```

## Test with this PR applied
1. Create a tmp directory
```
mkdir ~/tmp-also_install_shell_completions
```
2. Copy the [flake usage guide](https://github.com/dagger/nix#as-flake) to `~/tmp-also_install_shell_completions/flake.nix`
3. Modify the flake.nix to use this PR by changing the `dagger.url`
```nix
{
  inputs = {
    nixpkgs.url = "nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    dagger.url = "github:jljox/dagger-nix/also_install_shell_completions";
    dagger.inputs.nixpkgs.follows = "nixpkgs";
  };

  outputs = { self, nixpkgs, flake-utils, dagger, ... }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = import nixpkgs {inherit system; };
      in {
        devShells.default = pkgs.mkShell {
          buildInputs = [ dagger.packages.${system}.dagger ];
        };
      });
}
```
4. Change directory
```
cd ~/tmp-also_install_shell_completions
```
5. Install dagger in the nix shell
```
nix develop
```
6. Find where dagger has been installed in the nix store
```
which dagger
/nix/store/70k64mmhzvqjzlgh0lpivviljiyjkqa3-dagger-0.13.5/bin/dagger
```
7. Note that shell completions `have indeed been` installed
```
tree /nix/store/70k64mmhzvqjzlgh0lpivviljiyjkqa3-dagger-0.13.5
/nix/store/70k64mmhzvqjzlgh0lpivviljiyjkqa3-dagger-0.13.5
├── bin
│   └── dagger
└── share
    ├── bash-completion
    │   └── completions
    │       └── dagger.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── dagger.fish
    └── zsh
        └── site-functions
            └── _dagger
```

8. Example bash completion
```
bash-5.2$ dagger 
call        (Call one or more functions, interconnected into a pipeline)  init        (Initialize a new module)
completion  (Generate the autocompletion script for the specified shell)  install     (Install a dependency)
config      (Get or set module configuration)                             login       (Log in to Dagger Cloud)
core        (Call a core function)                                        logout      (Log out from Dagger Cloud)
develop     (Prepare a local module for development)                      query       (Send API queries to a dagger engine)
functions   (List available functions)                                    run         (Run a command in a Dagger session)
help        (Help about any command)                                      version     (Print dagger version)

```